### PR TITLE
Add -T option to SSH command for tunnel

### DIFF
--- a/scripts/ssh_tunnel.py
+++ b/scripts/ssh_tunnel.py
@@ -83,7 +83,7 @@ def ssh_tunnel(host: str = LOCALHOST_RUN) -> None:
 
     port = cmd_opts.port if cmd_opts.port else 7860
 
-    arg_string = f"ssh -R 80:127.0.0.1:{port} -o StrictHostKeyChecking=no -i {ssh_path.as_posix()} {host}"
+    arg_string = f"ssh -T -R 80:127.0.0.1:{port} -o StrictHostKeyChecking=no -i {ssh_path.as_posix()} {host}"
     args = shlex.split(arg_string)
 
     tunnel = subprocess.Popen(


### PR DESCRIPTION
The change in the SSH client's default pseudo-terminal (PTY) allocation behavior alters the operational state of the Ubuntu local terminal, resulting in anomalies in print line breaks and hampering program debugging.